### PR TITLE
Time Series: change how groups collapses to more like Scalars

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -14,6 +14,39 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<div class="group-toolbar">
+  <span>
+    <span
+      class="group-title"
+      aria-role="heading"
+      aria-level="3"
+      title="{{ groupName }}"
+      >{{ groupName }}</span
+    >
+    <span *ngIf="numberOfCards > 1" class="group-card-count"
+      >{{ numberOfCards }} cards</span
+    >
+  </span>
+  <button
+    *ngIf="showExpand(true)"
+    class="expand-group-button"
+    mat-icon-button
+    i18n-aria-label="A button that allows user to expand a tag group."
+    aria-label="Expand group"
+    (click)="groupExpansionToggled.emit()"
+  >
+    <mat-icon
+      *ngIf="isGroupExpanded; else expandMore"
+      svgIcon="expand_less_24px"
+    ></mat-icon>
+    <ng-template #expandMore>
+      <mat-icon svgIcon="expand_more_24px"></mat-icon>
+    </ng-template>
+  </button>
+</div>
+
+<div *ngIf="cardIdsWithMetadata.length >= 1">
+
 <ng-container
   *ngTemplateOutlet="groupControls; context: {isBottomControl: false}"
 ></ng-container>
@@ -34,6 +67,8 @@ limitations under the License.
   *ngTemplateOutlet="groupControls; context: {isBottomControl: true}"
 ></ng-container>
 
+</div>
+
 <ng-template #groupControls let-isBottomControl="isBottomControl">
   <div
     class="group-controls"
@@ -50,24 +85,6 @@ limitations under the License.
         (click)="handlePageChange(pageIndex - 1, $event.target)"
       >
         Previous
-      </button>
-    </span>
-    <span class="expand-container">
-      <button
-        *ngIf="showExpand(isBottomControl)"
-        class="expand-group-button"
-        mat-icon-button
-        i18n-aria-label="A button that allows user to expand a tag group."
-        aria-label="Expand group"
-        (click)="groupExpansionToggled.emit()"
-      >
-        <mat-icon
-          *ngIf="isGroupExpanded; else expandMore"
-          svgIcon="expand_less_24px"
-        ></mat-icon>
-        <ng-template #expandMore>
-          <mat-icon svgIcon="expand_more_24px"></mat-icon>
-        </ng-template>
       </button>
     </span>
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -19,6 +19,27 @@ $_background: map-get($tb-theme, background);
 
 :host {
   contain: content;
+  @include metrics-sub-view;
+
+  .group-toolbar {
+    @include tb-theme-foreground-prop(border-top, border, 1px solid);
+    // border-top on group-toolbar needs to be offset on sticky header for the
+    // flawless UI.
+    top: -1px;
+  }
+}
+
+.card-group:first-of-type .group-toolbar {
+  border-top: none;
+}
+
+.group-title {
+  @include metrics-card-group-title;
+}
+
+.group-card-count {
+  @include metrics-card-group-count-text;
+  margin-left: 6px;
 }
 
 .card-grid {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -44,6 +44,7 @@ export class CardGridComponent {
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
+  @Input() numberOfCards!: number;
 
   @Output() pageIndexChanged = new EventEmitter<number>();
   @Output() groupExpansionToggled = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -32,7 +32,7 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
 // Tag group can be collapsed. Even when it is collapsed, we show three cards.
-const ITEMS_COLLAPSED_CLIP_SIZE = 3;
+const ITEMS_COLLAPSED_CLIP_SIZE = 0;
 
 @Component({
   selector: 'metrics-card-grid',
@@ -43,6 +43,7 @@ const ITEMS_COLLAPSED_CLIP_SIZE = 3;
       [groupName]="groupName"
       [pageIndex]="normalizedPageIndex$ | async"
       [numPages]="numPages$ | async"
+      [numberOfCards]="numberOfCards"
       [showPaginationControls]="showPaginationControls$ | async"
       [cardIdsWithMetadata]="pagedItems$ | async"
       [cardObserver]="cardObserver"
@@ -58,6 +59,7 @@ export class CardGridContainer implements OnChanges, OnDestroy {
   @Input() groupName: string | null = null;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
   @Input() cardObserver!: CardObserver;
+  @Input() numberOfCards!: number;
 
   private readonly groupName$ = new BehaviorSubject<string | null>(null);
   readonly pageIndex$ = new BehaviorSubject<number>(0);

--- a/tensorboard/webapp/metrics/views/main_view/card_groups_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_groups_component.ts
@@ -26,22 +26,9 @@ import {CardGroup} from '../metrics_view_types';
       *ngFor="let group of cardGroups; trackBy: trackByGroup"
       class="card-group"
     >
-      <div class="group-toolbar">
-        <span>
-          <span
-            class="group-title"
-            aria-role="heading"
-            aria-level="3"
-            title="{{ group.groupName }}"
-            >{{ group.groupName }}</span
-          >
-          <span *ngIf="group.items.length > 1" class="group-card-count"
-            >{{ group.items.length | number }} cards</span
-          >
-        </span>
-      </div>
       <metrics-card-grid
         [cardIdsWithMetadata]="group.items"
+        [numberOfCards]="group.items.length"
         [cardObserver]="cardObserver"
         [groupName]="group.groupName"
       ></metrics-card-grid>


### PR DESCRIPTION
* Motivation for features / changes
Current Time Series dashboard expands each groups by default with a "expand button" if the number of cards exceed a certain number (default 3). We want to change how Time Series groups collapses to more like what Scalars does now. 
* Requirements
  - Still preserve pagination
  - Move expand icon to the header of each section.
  -  depends on the viewport, expand the first couple of sections

* Technical description of changes

To move the `expand-group-button` to the section header (`group-toolbar`) I have two options:
1. move the button from `<metrics-card-grid>` to upper level, `<metrics-card-groups>`
2. move the group-toolbar from the upper level `<metrics-card-groups-component>` to `<metrics-card-grid-component>`

I choose (2) because 
a. When it comes to check if the group is expandable and if is expanded, we need to use selector. The rule of thumb is to use selector in container, which makes it a bit tricky because we iterate `cardGroups` in component.ts. 
b. Also the above selectors requires `groupName` as input and in the level of `card_groups_component.ts` we just have a list of `cardGroups`. That is to say, even we use selector in the component file, we still need to have a map or list for this information and pass to `<metrics-card-grid>`, which becomes more messy.

To sum, 

- move group-toolbar into card_grid_component
- Passes `numberOfCards`  (the total number of cards per group) params to `card_grid_container` because the information could not be fulfilled by `cardIdsWithMetadata`  (which means the cards actually rendered in the section)
  (Please suggest a better way of doing this)

* Screenshots of UI changes
![Screen Shot 2021-11-03 at 9 15 18 PM](https://user-images.githubusercontent.com/1131010/140259227-08a9ee38-8051-4406-8cb3-993d1f09497d.png)

![Screen Shot 2021-11-03 at 9 15 37 PM](https://user-images.githubusercontent.com/1131010/140259252-713bd9f9-181d-4899-9bd6-504bffce19fa.png)

TODO:


1.make the whole 'group-toolbar' clickable not just the icon
2.depends on the viewport, expand the first couple of sections
