### PR TITLE
Shareability: introduce userViewBox in scalar and lineChart

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -29,7 +29,6 @@ _checked_in_file_descriptor_set = "descriptor.bin"
 rust_library(
     name = "rustboard_core",
     srcs = [
-        "lib.rs",
         "blob_key.rs",
         "cli.rs",
         "cli/dynamic_logdir.rs",
@@ -42,6 +41,7 @@ rust_library(
         "gcs/auth.rs",
         "gcs/client.rs",
         "gcs/logdir.rs",
+        "lib.rs",
         "logdir.rs",
         "masked_crc.rs",
         "reservoir.rs",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -220,8 +220,8 @@ export const timeSelectionChanged = createAction(
 );
 
 export const cardViewBoxChanged = createAction(
-  '[Metrics] Card View Box Changed',
-  props<{cardId: CardId; viewBox: Extent}>()
+  '[Metrics] Card User View Box Changed',
+  props<{cardId: CardId; userViewBox: Extent | null}>()
 );
 
 export const timeSelectionCleared = createAction(

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -31,6 +31,7 @@ tf_ts_library(
         "//tensorboard/webapp/util:ngrx",
         "//tensorboard/webapp/util:types",
         "//tensorboard/webapp/widgets/card_fob:types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1183,11 +1183,11 @@ const reducer = createReducer(
       rangeSelectionEnabled: nextRangeSelectionEnabled,
     };
   }),
-  on(actions.cardViewBoxChanged, (state, {cardId, viewBox}) => {
+  on(actions.cardViewBoxChanged, (state, {cardId, userViewBox}) => {
     const nextCardStateMap = {...state.cardStateMap};
     nextCardStateMap[cardId] = {
       ...nextCardStateMap[cardId],
-      userViewBox: viewBox,
+      userViewBox,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3441,7 +3441,7 @@ describe('metrics reducers', () => {
           state1,
           actions.cardViewBoxChanged({
             cardId: 'card2',
-            viewBox: {
+            userViewBox: {
               x: [0, 1],
               y: [2, 5],
             },
@@ -3479,7 +3479,7 @@ describe('metrics reducers', () => {
           state1,
           actions.cardViewBoxChanged({
             cardId: 'card1',
-            viewBox: {
+            userViewBox: {
               x: [1, 5],
               y: [2, 5],
             },

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -50,6 +50,7 @@ import {
   RunToSeries,
   TagMetadata,
 } from './metrics_types';
+import {Extent} from '../../widgets/line_chart_v2/lib/public_types';
 
 const selectMetricsState =
   createFeatureSelector<MetricsState>(METRICS_FEATURE_KEY);
@@ -534,6 +535,16 @@ export const getMetricsCardDataMinMax = createSelector(
   getCardStateMap,
   (cardStateMap: CardStateMap, cardId: CardId): MinMaxStep | undefined => {
     return cardStateMap[cardId]?.dataMinMax;
+  }
+);
+
+/**
+ * Returns user defined view extent. Null means no zoom in, user box is the same as data extent.
+ */
+export const getMetricsCardUserViewBox = createSelector(
+  getCardStateMap,
+  (cardStateMap: CardStateMap, cardId: CardId): Extent | null => {
+    return cardStateMap[cardId]?.userViewBox ?? null;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -899,6 +899,50 @@ describe('metrics selectors', () => {
     });
   });
 
+  describe('getMetricsCardUserViewBox', () => {
+    it('returns null when cardStateMap is undefined', () => {
+      const state = appStateFromMetricsState(buildMetricsState({}));
+      expect(selectors.getMetricsCardUserViewBox(state, 'card1')).toBeNull();
+    });
+
+    it('returns null when card has no cardState', () => {
+      const state1 = appStateFromMetricsState(
+        buildMetricsState({
+          cardStateMap: {},
+        })
+      );
+      expect(selectors.getMetricsCardUserViewBox(state1, 'card1')).toBeNull();
+
+      const state2 = appStateFromMetricsState(
+        buildMetricsState({
+          cardStateMap: {
+            card1: {},
+          },
+        })
+      );
+      expect(selectors.getMetricsCardUserViewBox(state2, 'card1')).toBeNull();
+    });
+
+    it('returns userViewBox when defined', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          cardStateMap: {
+            card1: {
+              userViewBox: {
+                x: [0, 10],
+                y: [11, 22],
+              },
+            },
+          },
+        })
+      );
+      expect(selectors.getMetricsCardUserViewBox(state, 'card1')).toEqual({
+        x: [0, 10],
+        y: [11, 22],
+      });
+    });
+  });
+
   describe('getPinnedCardsWithMetadata', () => {
     beforeEach(() => {
       selectors.getPinnedCardsWithMetadata.release();

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -138,7 +138,7 @@ export enum CardFeatureOverride {
 
 export type CardState = {
   dataMinMax: MinMaxStep;
-  userViewBox: Extent;
+  userViewBox: Extent | null;
   timeSelection: TimeSelection;
   stepSelectionOverride: CardFeatureOverride;
   rangeSelectionOverride: CardFeatureOverride;

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -393,6 +393,7 @@ tf_ts_library(
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
         "//tensorboard/webapp/widgets/line_chart_v2",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -121,6 +121,7 @@ limitations under the License.
       [ignoreYOutliers]="ignoreOutliers"
       [tooltipTemplate]="tooltip"
       [useDarkMode]="useDarkMode"
+      [userViewBox]="userViewBox"
       (onViewBoxOverridden)="isViewBoxOverridden = $event"
       (viewBoxChanged)="onLineChartZoom.emit($event)"
       [customVisTemplate]="lineChartCustomVis"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -98,6 +98,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() stepOrLinkedTimeSelection: TimeSelection | undefined;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
+  @Input() userViewBox!: Extent | null;
   @Input() columnHeaders!: ColumnHeader[];
   @Input() rangeEnabled!: boolean;
 
@@ -113,7 +114,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() editColumnHeaders = new EventEmitter<HeaderEditInfo>();
   @Output() openTableEditMenuToMode = new EventEmitter<DataTableMode>();
 
-  @Output() onLineChartZoom = new EventEmitter<Extent>();
+  @Output() onLineChartZoom = new EventEmitter<Extent | null>();
 
   @Output() onCardStateChanged = new EventEmitter<Partial<CardState>>();
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -51,6 +51,7 @@ import {
   getIsLinkedTimeProspectiveFobEnabled,
   getMetricsCardDataMinMax,
   getMetricsCardTimeSelection,
+  getMetricsCardUserViewBox,
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
   getMetricsCardRangeSelectionEnabled,
@@ -174,6 +175,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       [forceSvg]="forceSvg$ | async"
       [columnCustomizationEnabled]="columnCustomizationEnabled$ | async"
       [minMaxStep]="minMaxSteps$ | async"
+      [userViewBox]="userViewBox$ | async"
       [columnHeaders]="columnHeaders$ | async"
       [rangeEnabled]="rangeEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
@@ -221,6 +223,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
   columnHeaders$?: Observable<ColumnHeader[]>;
   minMaxSteps$?: Observable<MinMaxStep | undefined>;
+  userViewBox$?: Observable<Extent | null>;
   stepOrLinkedTimeSelection$?: Observable<TimeSelection | undefined>;
   cardState$?: Observable<Partial<CardState>>;
   rangeEnabled$?: Observable<boolean>;
@@ -376,6 +379,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         });
       }),
       shareReplay(1)
+    );
+
+    this.userViewBox$ = this.store.select(
+      getMetricsCardUserViewBox,
+      this.cardId
     );
 
     this.minMaxSteps$ = combineLatest([
@@ -657,10 +665,10 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.store.dispatch(stepSelectorToggled({affordance, cardId: this.cardId}));
   }
 
-  onLineChartZoom(lineChartViewBox: Extent) {
+  onLineChartZoom(lineChartViewBox: Extent | null) {
     this.store.dispatch(
       cardViewBoxChanged({
-        viewBox: lineChartViewBox,
+        userViewBox: lineChartViewBox,
         cardId: this.cardId,
       })
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -119,6 +119,7 @@ import {
   SortingOrder,
 } from './scalar_card_types';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
+import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 
 @Component({
   selector: 'line-chart',
@@ -153,6 +154,7 @@ class TestableLineChart {
   @Input() useDarkMode?: boolean;
   @Input()
   tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
+  @Input() userViewBox?: Extent;
 
   @Input()
   customChartOverlayTemplate!: TemplateRef<{}>;
@@ -388,6 +390,7 @@ describe('scalar card', () => {
       selectors.getMetricsCardRangeSelectionEnabled,
       false
     );
+    store.overrideSelector(selectors.getMetricsCardUserViewBox, null);
 
     dispatchedActions = [];
     spyOn(store, 'dispatch').and.callFake((action: Action) => {
@@ -2630,24 +2633,29 @@ describe('scalar card', () => {
           x: [9.235, 30.4],
           y: [0, 100],
         });
-
         fixture.componentInstance.onLineChartZoom({
           x: [8, 31],
           y: [0, 100],
         });
+        fixture.componentInstance.onLineChartZoom(null);
+
         expect(dispatchedActions).toEqual([
           cardViewBoxChanged({
-            viewBox: {
+            userViewBox: {
               x: [9.235, 30.4],
               y: [0, 100],
             },
             cardId: 'card1',
           }),
           cardViewBoxChanged({
-            viewBox: {
+            userViewBox: {
               x: [8, 31],
               y: [0, 100],
             },
+            cardId: 'card1',
+          }),
+          cardViewBoxChanged({
+            userViewBox: null,
             cardId: 'card1',
           }),
         ]);
@@ -4029,4 +4037,20 @@ describe('scalar card', () => {
       }));
     });
   });
+
+  it('renders userViewBox', fakeAsync(() => {
+    store.overrideSelector(selectors.getMetricsCardUserViewBox, {
+      x: [0, 1],
+      y: [11, 22],
+    });
+    const fixture = createComponent('card1');
+    fixture.detectChanges();
+
+    const lineChartEl = fixture.debugElement.query(Selector.LINE_CHART);
+    expect(lineChartEl).toBeTruthy();
+    expect(lineChartEl.componentInstance.userViewBox).toEqual({
+      x: [0, 1],
+      y: [11, 22],
+    });
+  }));
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -235,13 +235,13 @@ export class LineChartComponent
     }
 
     if (changes['userViewBox']) {
-      this.userViewBoxUpdated = true;
-      this.isViewBoxChanged = true;
       this.setIsViewBoxOverridden(false);
+      this.isViewBoxChanged = true;
 
       if (this.userViewBox) {
         this.setIsViewBoxOverridden(true);
         this.viewBox = this.userViewBox;
+        this.userViewBoxUpdated = true;
       }
     }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -234,10 +234,15 @@ export class LineChartComponent
       this.setIsViewBoxOverridden(false);
     }
 
-    if (changes['userViewBox'] && this.userViewBox) {
+    if (changes['userViewBox']) {
       this.userViewBoxUpdated = true;
-      this.viewBox = this.userViewBox;
-      this.setIsViewBoxOverridden(true);
+      this.isViewBoxChanged = true;
+      this.setIsViewBoxOverridden(false);
+
+      if (this.userViewBox) {
+        this.setIsViewBoxOverridden(true);
+        this.viewBox = this.userViewBox;
+      }
     }
 
     this.isViewBoxChanged =
@@ -501,19 +506,11 @@ export class LineChartComponent
   }
 
   onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {
-    this.setIsViewBoxOverridden(true);
-    this.isViewBoxChanged = true;
-    this.viewBox = dataExtent;
-    this.updateLineChart();
     this.viewBoxChanged.emit(dataExtent);
   }
 
   viewBoxReset() {
-    this.setIsViewBoxOverridden(false);
-    this.isViewBoxChanged = true;
-    this.updateLineChart();
     this.viewBoxChanged.emit(null);
-    this.userViewBox = null;
   }
 
   private setIsViewBoxOverridden(newValue: boolean): void {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -229,24 +229,19 @@ export class LineChartComponent
       this.useDarkModeUpdated = true;
     }
 
-    // Do not set isViewBoxOverridden to false until updated userViewBox has been reflected on the lineChart.
-    if (this.scaleUpdated && !this.userViewBoxUpdated) {
-      this.setIsViewBoxOverridden(false);
+    if (changes['userViewBox']) {
+      this.userViewBoxUpdated = true;
     }
 
-    if (changes['userViewBox']) {
+    if (this.userViewBoxUpdated) {
+      this.setIsViewBoxOverridden(!!this.userViewBox);
+    } else if (this.scaleUpdated) {
       this.setIsViewBoxOverridden(false);
-      this.isViewBoxChanged = true;
-
-      if (this.userViewBox) {
-        this.setIsViewBoxOverridden(true);
-        this.viewBox = this.userViewBox;
-        this.userViewBoxUpdated = true;
-      }
     }
 
     this.isViewBoxChanged =
       this.isViewBoxChanged ||
+      this.userViewBoxUpdated ||
       this.scaleUpdated ||
       (!this.isViewBoxOverridden && this.shouldUpdateDefaultViewBox(changes));
 
@@ -476,7 +471,9 @@ export class LineChartComponent
       this.userViewBoxUpdated = false;
     }
 
-    if (!this.isViewBoxOverridden && this.fixedViewBox) {
+    if (this.isViewBoxOverridden && !!this.userViewBox) {
+      this.viewBox = this.userViewBox;
+    } else if (!this.isViewBoxOverridden && this.fixedViewBox) {
       this.viewBox = this.fixedViewBox;
     } else if (!this.isViewBoxOverridden && this.isViewBoxChanged) {
       const dataExtent = computeDataSeriesExtent(

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -112,6 +112,8 @@ class TestableComponent {
 
   triggerViewBoxChange(viewBox: Extent) {
     this.chart.onViewBoxChanged({dataExtent: viewBox});
+    // Workaround to re-render the line chart.
+    this.userViewBox = viewBox;
   }
 }
 
@@ -371,6 +373,7 @@ describe('line_chart_v2/line_chart test', () => {
       x: [-5, 5],
       y: [0, 10],
     });
+    fixture.detectChanges();
     expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
 
     fixture.componentInstance.yScaleType = ScaleType.TIME;
@@ -575,12 +578,15 @@ describe('line_chart_v2/line_chart test', () => {
         seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
         yScaleType: ScaleType.LINEAR,
       });
+
       fixture.detectChanges();
 
       fixture.componentInstance.triggerViewBoxChange({
         x: [-5, 5],
         y: [0, 10],
       });
+      fixture.detectChanges();
+
       expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
 
       fixture.componentInstance.seriesData = [

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -731,50 +731,6 @@ describe('line_chart_v2/line_chart test', () => {
     });
   });
 
-  describe('#getIsViewBoxOverridden', () => {
-    it('emits when viewBox changes', () => {
-      const onViewBoxOverridden = jasmine.createSpy();
-      const fixture = createComponent({
-        seriesData: [
-          buildSeries({
-            id: 'foo',
-            points: [
-              {x: 0, y: 0},
-              {x: 1, y: -1},
-              {x: 2, y: 1},
-            ],
-          }),
-        ],
-        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
-        yScaleType: ScaleType.LINEAR,
-      });
-      fixture.componentInstance.yScaleType = ScaleType.LINEAR;
-      fixture.detectChanges();
-
-      fixture.componentInstance.chart
-        .getIsViewBoxOverridden()
-        .subscribe(onViewBoxOverridden);
-
-      // Initial value.
-      expect(onViewBoxOverridden).toHaveBeenCalledOnceWith(false);
-
-      fixture.componentInstance.triggerViewBoxChange({
-        x: [-5, 5],
-        y: [0, 10],
-      });
-
-      expect(onViewBoxOverridden.calls.allArgs()).toEqual([[false], [true]]);
-
-      fixture.componentInstance.yScaleType = ScaleType.TIME;
-      fixture.detectChanges();
-      expect(onViewBoxOverridden.calls.allArgs()).toEqual([
-        [false],
-        [true],
-        [false],
-      ]);
-    });
-  });
-
   describe('dark mode support', () => {
     it('sets class dark-mode', () => {
       const fixture = createComponent({
@@ -1044,6 +1000,33 @@ describe('line_chart_v2/line_chart test', () => {
         x: [0, 1],
         y: [0, 0.5],
       });
+    });
+
+    it('emits getIsViewBoxOverridden', () => {
+      const onViewBoxOverridden = jasmine.createSpy();
+      const fixture = createComponent({
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+
+      fixture.componentInstance.chart
+        .getIsViewBoxOverridden()
+        .subscribe(onViewBoxOverridden);
+      expect(onViewBoxOverridden).toHaveBeenCalledOnceWith(false);
+
+      fixture.componentInstance.userViewBox = {
+        x: [0, 1],
+        y: [0, 0.5],
+      };
+      fixture.detectChanges();
+      expect(onViewBoxOverridden.calls.allArgs()).toEqual([[false], [true]]);
     });
 
     it('does not update viewBox when data loaded afterward', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -1035,49 +1035,14 @@ describe('line_chart_v2/line_chart test', () => {
       expect(onViewBoxOverridden.calls.allArgs()).toEqual([[false], [true]]);
     });
 
-    it('does not update viewBox when data loaded afterward', () => {
-      const fixture = createComponent({
-        seriesData: [
-          buildSeries({
-            id: 'foo',
-            points: [],
-          }),
-        ],
-        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
-        yScaleType: ScaleType.LINEAR,
-      });
-      fixture.detectChanges();
-
-      fixture.componentInstance.userViewBox = {
-        x: [0, 1],
-        y: [0, 0.5],
-      };
-      fixture.detectChanges();
-
-      fixture.componentInstance.seriesData = [
-        buildSeries({
-          id: 'foo',
-          points: [
-            {x: 0, y: 0},
-            {x: 1, y: -1},
-            {x: 2, y: 1},
-          ],
-        }),
-      ];
-      fixture.detectChanges();
-
-      expect(fixture.componentInstance.chart.viewBox).toEqual({
-        x: [0, 1],
-        y: [0, 0.5],
-      });
-    });
-
-    it('updates viewBox with userView when the data loads later', () => {
+    it('does not change viewBox when data loaded afterward', () => {
       const fixture = createComponent({
         seriesData: [],
         seriesMetadataMap: {},
         yScaleType: ScaleType.LINEAR,
       });
+      fixture.detectChanges();
+
       fixture.componentInstance.userViewBox = {
         x: [0, 1],
         y: [0, 0.5],

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -1072,6 +1072,36 @@ describe('line_chart_v2/line_chart test', () => {
       });
     });
 
+    it('updates viewBox with userView when the data loads later', () => {
+      const fixture = createComponent({
+        seriesData: [],
+        seriesMetadataMap: {},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.componentInstance.userViewBox = {
+        x: [0, 1],
+        y: [0, 0.5],
+      };
+      fixture.detectChanges();
+
+      fixture.componentInstance.seriesData = [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ];
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.chart.viewBox).toEqual({
+        x: [0, 1],
+        y: [0, 0.5],
+      });
+    });
+
     it('updates viewBox with data extent when userView is null', () => {
       const fixture = createComponent({
         seriesData: [


### PR DESCRIPTION
## Motivation for features / changes
Take userViewBox in state and apply on scalar line chart.

## Technical description of changes
- Select `userViewBox` from state and pass all the way down to `line_chart_component`
- Update `userViewBox` in state on line chart zoom (includes reset view box)
  - Set `userViewBox` to null when view box is rest. This saves the effort of checking viewBox and userViewBox equivalence to determine correct `isViewBoxOverridden` value
- In `line_chart_component`,
  - `userViewBox` might be updated before data series change coming in, thus we need `userViewBoxUpdated` variable to mark until next `updateLineChart()` being called. (otherwise `isViewBoxOverridden` will not be updated correctly and have unwanted disabled behavior of reset icon)
  - On the case of user view box is the same as data extent, explicitly sets `userViewBox` to null instead of using implicit undefined.

## Screenshots of UI changes (or N/A)
Manually check scalar zoom in/out behavior. Nothing is expected to change.
